### PR TITLE
reject same-site requests by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,12 +424,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_allows_same_site_requests() {
-        let request = request!(site => "same-site", mode => "navigate", dest => "document");
+    async fn it_rejects_same_site_requests() {
+        let request = request!(site => "same-site", mode => "cors", dest => "empty");
 
         assert_request!(request, |response: http::Response<()>| {
-            check!(response.status().is_success());
+            check!(response.status() == StatusCode::FORBIDDEN);
         });
+    }
+
+    #[tokio::test]
+    async fn it_allows_same_site_requests_if_configured() {
+        let layer = SecFetchLayer::new(|policy| {
+            policy.allow_same_site();
+        });
+        let request = request!(site => "same-site", mode => "cors", dest => "empty");
+
+        assert_request!(
+            request,
+            |response: http::Response<()>| {
+                check!(response.status().is_success());
+            },
+            layer
+        );
     }
 
     #[tokio::test]
@@ -461,6 +477,15 @@ mod tests {
     #[tokio::test]
     async fn it_allows_navigation_requests() {
         let request = request!(site => "cross-site", mode => "navigate", dest => "document");
+
+        assert_request!(request, |response: http::Response<()>| {
+            check!(response.status().is_success());
+        });
+    }
+
+    #[tokio::test]
+    async fn it_allows_same_site_navigation_requests() {
+        let request = request!(site => "same-site", mode => "navigate", dest => "document");
 
         assert_request!(request, |response: http::Response<()>| {
             check!(response.status().is_success());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! In short, this crate allows to protect web resources from cross-site inclusion and abuse by validating the [Fetch Metadata] headers and ensuring that only "safe" cross-site requests are allowed. In this context, "safe" means:
 //!
-//! - the request comes from the same origin (the site's exact scheme, host, and port), same site (any subdomain of the current domain), or are user-initiated (e.g. clicking on a bookmark, directly entering the website's address), OR...
+//! - the request comes from the same origin (the site's exact scheme, host, and port), or are user-initiated (e.g. clicking on a bookmark, directly entering the website's address), OR...
 //! - the request is a simple GET request coming from a navigation event (e.g. clicking on a link on another website), as long as it's not being embedded in elements like `<object>` or `<iframe>`.
 //!
 //! <div class="warning">
@@ -120,6 +120,16 @@
 //! #
 //! SecFetchLayer::new(|policy| {
 //!     policy.reject_missing_metadata();
+//! });
+//! ```
+//!
+//! Same-site (any subdomain of the current domain) requests are not allowed by default. This can be enabled by setting the [allow_same_site](PolicyBuilder::allow_same_site) flag on the evaluation policy.
+//!
+//! ```
+//! # use tower_sec_fetch::SecFetchLayer;
+//! #
+//! SecFetchLayer::new(|policy| {
+//!     policy.allow_same_site();
 //! });
 //! ```
 //!

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -6,6 +6,7 @@ use crate::header;
 pub struct Policy {
     reject_missing_metadata: bool,
     allow_safe_methods: bool,
+    allow_same_site: bool,
 }
 
 impl Policy {
@@ -48,15 +49,27 @@ impl Policy {
             return !self.reject_missing_metadata;
         };
 
-        if header_in(sec_fetch_site, ["same-origin", "same-site", "none"]) {
+        if header_in(sec_fetch_site, ["same-origin", "none"]) {
             #[cfg(feature = "tracing")]
             tracing::trace!(
                 method = %request.method(),
                 path = request.uri().path(),
-                "request is same-site or user initiated: allowed",
+                "request is same-origin or user initiated: allowed",
             );
 
-            // request is same-site or user initiated
+            // request is same-origin or user initiated
+            return true;
+        }
+
+        if self.allow_same_site && header_in(sec_fetch_site, ["same-site"]) {
+            #[cfg(feature = "tracing")]
+            tracing::trace!(
+                method = %request.method(),
+                path = request.uri().path(),
+                "request is same-site: allowed",
+            );
+
+            // request is same-site
             return true;
         }
 
@@ -91,6 +104,7 @@ impl Policy {
 pub struct PolicyBuilder {
     reject_missing_metadata: bool,
     allow_safe_methods: bool,
+    allow_same_site: bool,
 }
 
 impl PolicyBuilder {
@@ -98,6 +112,7 @@ impl PolicyBuilder {
         Self {
             reject_missing_metadata: false,
             allow_safe_methods: false,
+            allow_same_site: false,
         }
     }
 
@@ -114,10 +129,17 @@ impl PolicyBuilder {
         self
     }
 
+    /// Allow requests from the same site (e.g. different subdomain)
+    pub fn allow_same_site(&mut self) -> &mut Self {
+        self.allow_same_site = true;
+        self
+    }
+
     pub(crate) fn build(self) -> Policy {
         Policy {
             reject_missing_metadata: self.reject_missing_metadata,
             allow_safe_methods: self.allow_safe_methods,
+            allow_same_site: self.allow_same_site,
         }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/MatteoJoliveau/tower-sec-fetch/issues/4 same-site requests should only be optionally allowed as "different origins in the same site can actually sit at very different trust levels".

This adds a `allow_same_site` function to the `PolicyBuilder` to re-enable the previous behavior.